### PR TITLE
Remove superfluous project ':app' from Gradle settings

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -8,4 +8,3 @@
  */
 
 rootProject.name = 'YtToZara'
-include('app')


### PR DESCRIPTION
Fixes #121